### PR TITLE
Add changelog url to response

### DIFF
--- a/app/Models/Version.php
+++ b/app/Models/Version.php
@@ -17,7 +17,7 @@ class Version extends Model
         'security_support_until' => 'datetime',
     ];
 
-    protected $appends = ['needs_patch', 'needs_upgrade'];
+    protected $appends = ['needs_patch', 'needs_upgrade', 'changelog_url'];
 
     public function scopeLatestRelease($query)
     {
@@ -53,6 +53,11 @@ class Version extends Model
     public function getNeedsPatchAttribute()
     {
         return $this->attributes['needs_patch'] = $this->needs_upgrade || $this->release !== Version::latestReleaseForMinorVersion($this->major, $this->minor)->first()->release;
+    }
+
+    public function getChangelogUrlAttribute()
+    {
+        return  "https://www.php.net/ChangeLog-{$this->major}.php#{$this->__toString()}";
     }
 
     public function __toString()

--- a/tests/Feature/VersionControllerTest.php
+++ b/tests/Feature/VersionControllerTest.php
@@ -292,4 +292,15 @@ class VersionControllerTest extends TestCase
         $this->getJson('api/versions/latest')
             ->assertJsonFragment([$latest->__toString()]);
     }
+
+    /** @test */
+    public function it_returns_the_expected_value_for_changelog_url()
+    {
+        $version = Version::factory()->create();
+
+        $this->assertSame(
+            "https://www.php.net/ChangeLog-{$version->major}.php#{$version->__toString()}",
+            $version->changelog_url
+        );
+    }
 }


### PR DESCRIPTION
Closes #2. Uses php.net conventions to add links to the changelog for each release.

New sample response:
<img width="620" alt="Screen Shot 2021-10-05 at 11 04 49 AM" src="https://user-images.githubusercontent.com/4378273/136049936-ef32a4a8-a1ef-40bc-bb24-3256eea4e9c0.png">
