### PR TITLE
Extract data to response

### DIFF
--- a/ApiDocs.md
+++ b/ApiDocs.md
@@ -8,43 +8,34 @@ Returns all PHP releases 5.6+.
 
   ```json
     [{
-      "id": 1,
       "major": 8,
       "minor": 0,
       "release": 10,
       "tagged_at": "2021-08-24T17:48:14.000000Z",
       "active_support_until": "2022-11-26T18:03:09.000000Z",
       "security_support_until": "2023-11-26T18:03:09.000000Z",
-      "created_at": "2021-09-10T17:53:23.000000Z",
-      "updated_at": "2021-09-10T17:53:23.000000Z",
       "needs_patch": false,
       "needs_upgrade": false,
       "changelog_url": "https://www.php.net/ChangeLog-8.php#8.0.10"
     },
     {
-      "id": 4,
       "major": 8,
       "minor": 0,
       "release": 9,
       "tagged_at": "2021-07-29T14:58:35.000000Z",
       "active_support_until": "2022-11-26T18:03:09.000000Z",
       "security_support_until": "2023-11-26T18:03:09.000000Z",
-      "created_at": "2021-09-10T17:53:23.000000Z",
-      "updated_at": "2021-09-10T17:53:23.000000Z",
       "needs_patch": true,
       "needs_upgrade": false,
       "changelog_url": "https://www.php.net/ChangeLog-8.php#8.0.9"
     },
     {
-      "id": 6,
       "major": 8,
       "minor": 0,
       "release": 8,
       "tagged_at": "2021-06-29T09:56:31.000000Z",
       "active_support_until": "2022-11-26T18:03:09.000000Z",
       "security_support_until": "2023-11-26T18:03:09.000000Z",
-      "created_at": "2021-09-10T17:53:23.000000Z",
-      "updated_at": "2021-09-10T17:53:23.000000Z",
       "needs_patch": true,
       "needs_upgrade": false, 
       "changelog_url": "https://www.php.net/ChangeLog-8.php#8.0.8"
@@ -60,15 +51,12 @@ Takes string (ex: "7", "7.2", "7.2.12") and returns information for the major/mi
   ```json
   {
     "provided": {
-      "id": 85,
       "major": 7,
       "minor": 3,
       "release": 3,
       "tagged_at": "2019-03-05T13:49:42.000000Z",
       "active_support_until": "2020-12-06T16:08:24.000000Z",
       "security_support_until": "2021-12-06T16:08:24.000000Z",
-      "created_at": "2021-09-10T17:53:24.000000Z",
-      "updated_at": "2021-09-10T17:53:24.000000Z",
       "needs_patch": true,
       "needs_upgrade": true,
       "changelog_url": "https://www.php.net/ChangeLog-7.php#7.3.3"
@@ -95,15 +83,12 @@ Takes a string `active` or `security` and returns the minimum release supported.
 
   ```json
   {
-    "id": 2,
     "major": 7,
     "minor": 4,
     "release": 23,
     "tagged_at": "2021-08-24T17:35:21.000000Z",
     "active_support_until": "2021-11-28T20:46:01.000000Z",
     "security_support_until": "2022-11-28T20:46:01.000000Z",
-    "created_at": "2021-09-10T17:53:23.000000Z",
-    "updated_at": "2021-09-10T17:53:23.000000Z",
     "needs_patch": false,
     "needs_upgrade": false,
     "changelog_url": "https://www.php.net/ChangeLog-7.php#7.4.23"

--- a/README.md
+++ b/README.md
@@ -15,43 +15,34 @@ The following endpoints are currently available, along with the optional `/versi
 
   ```json
     [{
-      "id": 1,
       "major": 8,
       "minor": 0,
       "release": 10,
       "tagged_at": "2021-08-24T17:48:14.000000Z",
       "active_support_until": "2022-11-26T18:03:09.000000Z",
       "security_support_until": "2023-11-26T18:03:09.000000Z",
-      "created_at": "2021-09-10T17:53:23.000000Z",
-      "updated_at": "2021-09-10T17:53:23.000000Z",
       "needs_patch": false,
       "needs_upgrade": false,
       "changelog_url": "https://www.php.net/ChangeLog-8.php#8.0.10"
     },
     {
-      "id": 4,
       "major": 8,
       "minor": 0,
       "release": 9,
       "tagged_at": "2021-07-29T14:58:35.000000Z",
       "active_support_until": "2022-11-26T18:03:09.000000Z",
       "security_support_until": "2023-11-26T18:03:09.000000Z",
-      "created_at": "2021-09-10T17:53:23.000000Z",
-      "updated_at": "2021-09-10T17:53:23.000000Z",
       "needs_patch": true,
       "needs_upgrade": false,
       "changelog_url": "https://www.php.net/ChangeLog-8.php#8.0.9"
     },
     {
-      "id": 6,
       "major": 8,
       "minor": 0,
       "release": 8,
       "tagged_at": "2021-06-29T09:56:31.000000Z",
       "active_support_until": "2022-11-26T18:03:09.000000Z",
       "security_support_until": "2023-11-26T18:03:09.000000Z",
-      "created_at": "2021-09-10T17:53:23.000000Z",
-      "updated_at": "2021-09-10T17:53:23.000000Z",
       "needs_patch": true,
       "needs_upgrade": false,
       "changelog_url": "https://www.php.net/ChangeLog-8.php#8.0.8"
@@ -66,15 +57,12 @@ The following endpoints are currently available, along with the optional `/versi
   ```json
   {
     "provided": {
-      "id": 85,
       "major": 7,
       "minor": 3,
       "release": 3,
       "tagged_at": "2019-03-05T13:49:42.000000Z",
       "active_support_until": "2020-12-06T16:08:24.000000Z",
       "security_support_until": "2021-12-06T16:08:24.000000Z",
-      "created_at": "2021-09-10T17:53:24.000000Z",
-      "updated_at": "2021-09-10T17:53:24.000000Z",
       "needs_patch": true,
       "needs_upgrade": true,
       "changelog_url": "https://www.php.net/ChangeLog-7.php#7.3.3"
@@ -97,15 +85,12 @@ The following endpoints are currently available, along with the optional `/versi
   
   ```json
   {
-    "id": 2,
     "major": 7,
     "minor": 4,
     "release": 23,
     "tagged_at": "2021-08-24T17:35:21.000000Z",
     "active_support_until": "2021-11-28T20:46:01.000000Z",
     "security_support_until": "2022-11-28T20:46:01.000000Z",
-    "created_at": "2021-09-10T17:53:23.000000Z",
-    "updated_at": "2021-09-10T17:53:23.000000Z",
     "needs_patch": false,
     "needs_upgrade": false,
     "changelog_url": "https://www.php.net/ChangeLog-7.php#7.4.23"

--- a/app/Http/Controllers/ReleaseController.php
+++ b/app/Http/Controllers/ReleaseController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Resources\ReleaseResource;
 use App\Models\Release;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -10,14 +11,12 @@ class ReleaseController
 {
     public function index()
     {
-        return response()->json(
-            Release::orderByDesc('tagged_at')->get()
-        );
+        return ReleaseResource::collection(Release::orderByDesc('tagged_at')->get());
     }
 
     public function minimumSupported(string $supportType = 'active')
     {
-        return response()->json(
+        return new ReleaseResource(
             Release::where("{$supportType}_support_until", '>', Carbon::now())
                 ->orderBy('major')
                 ->orderBy('minor')
@@ -47,16 +46,10 @@ class ReleaseController
                 'release' => $release[2],
             ]);
 
-            return response()->json([
-                'provided' => $provided,
-                'latest_release' => (string) Release::orderByDesc('major')
-                    ->orderByDesc('minor')
-                    ->orderByDesc('release')
-                    ->first(),
-            ]);
+            return new ReleaseResource($provided);
         }
 
-        return response()->json(
+        return ReleaseResource::collection(
             Release::query()
                 ->when(array_key_exists(1, $release), function ($query) use ($release) {
                     $query->where('major', $release[0])

--- a/app/Http/Resources/ReleaseResource.php
+++ b/app/Http/Resources/ReleaseResource.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\Release;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ReleaseResource extends JsonResource
+{
+    public static $wrap = 'provided';
+
+    public function toArray($request)
+    {
+        return [
+            'major' => $this->major,
+            'minor' => $this->minor,
+            'release' => $this->release,
+            'tagged_at' => $this->tagged_at,
+            'active_support_until' => $this->active_support_until,
+            'security_support_until' => $this->security_support_until,
+            'needs_patch' => $this->needs_patch,
+            'needs_upgrade' => $this->needs_upgrade,
+            'changelog_url' => $this->changelog_url,
+        ];
+    }
+
+    public function with($request)
+    {
+        return [
+            'latest_release' => (string) Release::orderByDesc('major')
+                ->orderByDesc('minor')
+                ->orderByDesc('release')
+                ->first(),
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -23,6 +24,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        JsonResource::withoutWrapping();
     }
 }

--- a/tests/Feature/ReleaseControllerTest.php
+++ b/tests/Feature/ReleaseControllerTest.php
@@ -121,20 +121,17 @@ class ReleaseControllerTest extends TestCase
         $this->getJson('api/releases/' . phpversion('tidy'))
             ->assertJsonStructure([
                 'provided' => [
-                    'id',
                     'major',
                     'minor',
                     'release',
                     'tagged_at',
                     'active_support_until',
                     'security_support_until',
-                    'created_at',
-                    'updated_at',
                     'needs_patch',
                     'needs_upgrade',
                     'changelog_url',
                 ],
-                'latest_release'
+                'latest_release',
             ])
             ->assertJsonFragment([
                 'major' => $currentRelease->major,
@@ -168,15 +165,12 @@ class ReleaseControllerTest extends TestCase
         $this->getJson('api/releases/8')
             ->assertJsonStructure([
                 '*' => [
-                    'id',
                     'major',
                     'minor',
                     'release',
                     'tagged_at',
                     'active_support_until',
                     'security_support_until',
-                    'created_at',
-                    'updated_at',
                     'needs_patch',
                     'needs_upgrade',
                     'changelog_url',

--- a/tests/Feature/ReleaseControllerTest.php
+++ b/tests/Feature/ReleaseControllerTest.php
@@ -119,6 +119,23 @@ class ReleaseControllerTest extends TestCase
         ]);
 
         $this->getJson('api/releases/' . phpversion('tidy'))
+            ->assertJsonStructure([
+                'provided' => [
+                    'id',
+                    'major',
+                    'minor',
+                    'release',
+                    'tagged_at',
+                    'active_support_until',
+                    'security_support_until',
+                    'created_at',
+                    'updated_at',
+                    'needs_patch',
+                    'needs_upgrade',
+                    'changelog_url',
+                ],
+                'latest_release'
+            ])
             ->assertJsonFragment([
                 'major' => $currentRelease->major,
                 'minor' => $currentRelease->minor,
@@ -149,6 +166,22 @@ class ReleaseControllerTest extends TestCase
             ->create();
 
         $this->getJson('api/releases/8')
+            ->assertJsonStructure([
+                '*' => [
+                    'id',
+                    'major',
+                    'minor',
+                    'release',
+                    'tagged_at',
+                    'active_support_until',
+                    'security_support_until',
+                    'created_at',
+                    'updated_at',
+                    'needs_patch',
+                    'needs_upgrade',
+                    'changelog_url',
+                ],
+            ])
             ->assertJsonCount(5);
 
         $this->getJson('api/releases/7')


### PR DESCRIPTION
Note: Removes the internal id and timestamp attributes from the Release response. I'm guessing this will have negligible impact on usage, but I'm open to any input there.