### PR TITLE
Add analytics

### DIFF
--- a/app/Http/Controllers/HitController.php
+++ b/app/Http/Controllers/HitController.php
@@ -20,12 +20,6 @@ class HitController
                 ->orderByDesc('count')
                 ->take(5)
                 ->get(),
-
-//            'top' => Hit::all()->countBy(function ($item) {
-//                return $item->endpoint;
-//            })->sortBy(function ($key, $value) {
-//                return $value;
-//            })->take(5),
         ]);
     }
 }

--- a/app/Http/Controllers/HitController.php
+++ b/app/Http/Controllers/HitController.php
@@ -3,23 +3,29 @@
 namespace App\Http\Controllers;
 
 use App\Models\Hit;
+use Illuminate\Support\Facades\DB;
 
 class HitController
 {
     public function __invoke()
     {
-        $stats = Hit::all();
-
         return view('stats', [
-            'hits' => $stats,
+            'hits' => Hit::simplePaginate(),
             'week' => Hit::forTimePeriod('week'),
             'month' => Hit::forTimePeriod('month'),
             'year' => Hit::forTimePeriod('year'),
-            'top' => $stats->countBy(function ($item) {
-                return $item->endpoint;
-            })->sortBy(function ($key, $value) {
-                return $value;
-            })->take(5),
+            'top' => DB::table('hits')
+                ->select(DB::raw('count(*) as count, endpoint'))
+                ->groupBy('endpoint')
+                ->orderByDesc('count')
+                ->take(5)
+                ->get(),
+
+//            'top' => Hit::all()->countBy(function ($item) {
+//                return $item->endpoint;
+//            })->sortBy(function ($key, $value) {
+//                return $value;
+//            })->take(5),
         ]);
     }
 }

--- a/app/Http/Controllers/HitController.php
+++ b/app/Http/Controllers/HitController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Hit;
+use Illuminate\Support\Facades\DB;
+
+class HitController
+{
+    public function __invoke()
+    {
+        $stats = Hit::all();
+
+        return view('stats', [
+            'hits' => $stats,
+            'week' => Hit::forTimePeriod('week'),
+            'month' => Hit::forTimePeriod('month'),
+            'year' => Hit::forTimePeriod('year'),
+            'top' => $stats->countBy(function ($item) {
+                return $item->endpoint;
+            })->sortBy(function($key, $value) {
+                return $value;
+            })->take(5),
+        ]);
+    }
+}

--- a/app/Http/Controllers/HitController.php
+++ b/app/Http/Controllers/HitController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Models\Hit;
-use Illuminate\Support\Facades\DB;
 
 class HitController
 {
@@ -18,7 +17,7 @@ class HitController
             'year' => Hit::forTimePeriod('year'),
             'top' => $stats->countBy(function ($item) {
                 return $item->endpoint;
-            })->sortBy(function($key, $value) {
+            })->sortBy(function ($key, $value) {
                 return $value;
             })->take(5),
         ]);

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\RecordHit::class,
     ];
 
     /**

--- a/app/Http/Middleware/RecordHit.php
+++ b/app/Http/Middleware/RecordHit.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Hit;
+use Carbon\Carbon;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class RecordHit
+{
+    public function handle(Request $request, Closure $next)
+    {
+        return $next($request);
+    }
+
+    public function terminate($request): void
+    {
+        $uri = $request->getRequestUri();
+        $userAgent = $request->header('user-agent');
+
+        if ($uri === '/'
+            || explode('/', $uri)[1] === 'api'
+            && ! str_contains(strtolower($userAgent), 'bot')
+            && ! str_contains(strtolower($userAgent), 'spider')
+        ) {
+            Hit::create([
+                'endpoint' => $uri,
+                'user_agent' => $userAgent,
+            ]);
+        }
+    }
+}

--- a/app/Http/Middleware/RecordHit.php
+++ b/app/Http/Middleware/RecordHit.php
@@ -3,10 +3,8 @@
 namespace App\Http\Middleware;
 
 use App\Models\Hit;
-use Carbon\Carbon;
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class RecordHit
 {
@@ -20,7 +18,8 @@ class RecordHit
         $uri = $request->getRequestUri();
         $userAgent = $request->header('user-agent');
 
-        if ($uri === '/'
+        if (
+            $uri === '/'
             || explode('/', $uri)[1] === 'api'
             && ! str_contains(strtolower($userAgent), 'bot')
             && ! str_contains(strtolower($userAgent), 'spider')

--- a/app/Models/Hit.php
+++ b/app/Models/Hit.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Hit extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['endpoint', 'user_agent'];
+
+    public static function forTimePeriod(string $period = 'week')
+    {
+        $now = CarbonImmutable::now();
+
+        $currentPeriodHits = Hit::hitsBetween($now->sub($period, 1), $now);
+        $previousPeriodHits = Hit::hitsBetween($now->sub($period, 2), $now->sub($period, 1)->subDay());
+
+        return [
+            'current' => $currentPeriodHits,
+            'previous' => $previousPeriodHits,
+            'change' => $previousPeriodHits
+                ? intval((($currentPeriodHits - $previousPeriodHits) / $previousPeriodHits) * 100)
+                : 100,
+        ];
+    }
+
+    private static function hitsBetween(CarbonImmutable $start, CarbonImmutable $end)
+    {
+        return Hit::whereBetween('created_at', [
+            $start->toDateTimeString(),
+            $end->toDateTimeString()
+        ])->count();
+    }
+}

--- a/app/Models/Hit.php
+++ b/app/Models/Hit.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -33,7 +32,7 @@ class Hit extends Model
     {
         return Hit::whereBetween('created_at', [
             $start->toDateTimeString(),
-            $end->toDateTimeString()
+            $end->toDateTimeString(),
         ])->count();
     }
 }

--- a/app/Models/Hit.php
+++ b/app/Models/Hit.php
@@ -12,7 +12,14 @@ class Hit extends Model
 
     protected $fillable = ['endpoint', 'user_agent'];
 
-    public static function forTimePeriod(string $period = 'week')
+    /**
+     * @param string $period    Available Options: millenium, century, decade,
+     *                          year, quarter, month, week, day, weekday, hour,
+     *                          minute, second, microsecond
+     *
+     * @return array
+     */
+    public static function forTimePeriod(string $period = 'week'): array
     {
         $now = CarbonImmutable::now();
 
@@ -22,7 +29,7 @@ class Hit extends Model
         return [
             'current' => $currentPeriodHits,
             'previous' => $previousPeriodHits,
-            'change' => $previousPeriodHits
+            'changePercent' => $previousPeriodHits
                 ? intval((($currentPeriodHits - $previousPeriodHits) / $previousPeriodHits) * 100)
                 : 100,
         ];

--- a/database/factories/HitFactory.php
+++ b/database/factories/HitFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class HitFactory extends Factory
+{
+    public function definition()
+    {
+        return [
+            'endpoint' => '/api/releases/8.0',
+            'user_agent' => $this->faker->userAgent,
+        ];
+    }
+}

--- a/database/factories/HitFactory.php
+++ b/database/factories/HitFactory.php
@@ -9,7 +9,7 @@ class HitFactory extends Factory
     public function definition()
     {
         return [
-            'endpoint' => '/api/releases/8.0',
+            'endpoint' => '/api/releases/' . random_int(5, 9) . '.' . random_int(0, 12) . random_int(0, 25),
             'user_agent' => $this->faker->userAgent,
         ];
     }

--- a/database/migrations/2022_08_25_222630_create_hits_table.php
+++ b/database/migrations/2022_08_25_222630_create_hits_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateHitsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('hits', function (Blueprint $table) {
+            $table->id();
+            $table->string('endpoint');
+            $table->string('user_agent');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('hits');
+    }
+}

--- a/resources/views/stats.blade.php
+++ b/resources/views/stats.blade.php
@@ -30,7 +30,7 @@
         </div>
 
         <div class="px-4 py-5 bg-white shadow rounded-lg overflow-hidden sm:p-6">
-            <dt class="text-sm font-medium text-gray-500 truncate">Top endpoint</dt>
+            <dt class="text-sm font-medium text-gray-500 truncate">Top Endpoints</dt>
             <dd class="mt-1 text-xs tracking-tight font-semibold text-gray-900">
                 @foreach ($top as $key => $value)
                     <div class="flex justify-between my-2">
@@ -43,7 +43,7 @@
     </dl>
 
 
-    <table class="min-w-full divide-y divide-gray-300">
+    <table class="min-w-full divide-y divide-gray-300 mt-4">
         <thead class="bg-gray-50">
             <tr>
                 <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Endpoint</th>

--- a/resources/views/stats.blade.php
+++ b/resources/views/stats.blade.php
@@ -5,7 +5,7 @@
         <div class="px-4 py-5 bg-white shadow rounded-lg overflow-hidden sm:p-6">
             <dt class="text-sm font-medium text-gray-500 truncate">Last Week</dt>
             <dd class="mt-1 text-3xl tracking-tight font-semibold text-gray-900">
-                <h3>{{ $week['current']}} hits</h3>
+                <h3>{{ $week['current'] }} hits</h3>
                 <p class="text-gray-500 text-sm">Previous: {{ $week['previous'] }}</p>
                 <p class="text-gray-500 text-sm">Percent Change: {{ $week['change'] }}%</p>
             </dd>
@@ -14,7 +14,7 @@
         <div class="px-4 py-5 bg-white shadow rounded-lg overflow-hidden sm:p-6">
             <dt class="text-sm font-medium text-gray-500 truncate">Last Month</dt>
             <dd class="mt-1 text-3xl tracking-tight font-semibold text-gray-900">
-                <h3>{{ $month['current']}} hits</h3>
+                <h3>{{ $month['current'] }} hits</h3>
                 <p class="text-gray-500 text-sm">Previous: {{ $month['previous'] }}</p>
                 <p class="text-gray-500 text-sm">Percent Change: {{ $month['change'] }}%</p>
             </dd>
@@ -23,7 +23,7 @@
         <div class="px-4 py-5 bg-white shadow rounded-lg overflow-hidden sm:p-6">
             <dt class="text-sm font-medium text-gray-500 truncate">All Time</dt>
             <dd class="mt-1 text-3xl tracking-tight font-semibold text-gray-900">
-                <h3>{{ $year['current']}} hits</h3>
+                <h3>{{ $year['current'] }} hits</h3>
                 <p class="text-gray-500 text-sm">Previous: {{ $year['previous'] }}</p>
                 <p class="text-gray-500 text-sm">Percent Change: {{ $year['change'] }}%</p>
             </dd>
@@ -32,7 +32,7 @@
         <div class="px-4 py-5 bg-white shadow rounded-lg overflow-hidden sm:p-6">
             <dt class="text-sm font-medium text-gray-500 truncate">Top endpoint</dt>
             <dd class="mt-1 text-xs tracking-tight font-semibold text-gray-900">
-                @foreach($top as $key => $value)
+                @foreach ($top as $key => $value)
                     <div class="flex justify-between my-2">
                         <p>{{ $key }}</p>
                         <p>{{ $value }}</p>
@@ -52,11 +52,11 @@
             </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
-            @foreach($hits as $hit)
+            @foreach ($hits as $hit)
                 <tr>
-                    <td class="whitespace-nowrap py-4 pl-4 text-sm text-gray-500">{{ $hit->endpoint}}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ $hit->user_agent}}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ $hit->created_at}}</td>
+                    <td class="whitespace-nowrap py-4 pl-4 text-sm text-gray-500">{{ $hit->endpoint }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ $hit->user_agent }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ $hit->created_at }}</td>
                 </tr>
             @endforeach
         </tbody>

--- a/resources/views/stats.blade.php
+++ b/resources/views/stats.blade.php
@@ -1,0 +1,64 @@
+@extends('layouts.app')
+
+@section('content')
+    <dl class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-4">
+        <div class="px-4 py-5 bg-white shadow rounded-lg overflow-hidden sm:p-6">
+            <dt class="text-sm font-medium text-gray-500 truncate">Last Week</dt>
+            <dd class="mt-1 text-3xl tracking-tight font-semibold text-gray-900">
+                <h3>{{ $week['current']}} hits</h3>
+                <p class="text-gray-500 text-sm">Previous: {{ $week['previous'] }}</p>
+                <p class="text-gray-500 text-sm">Percent Change: {{ $week['change'] }}%</p>
+            </dd>
+        </div>
+
+        <div class="px-4 py-5 bg-white shadow rounded-lg overflow-hidden sm:p-6">
+            <dt class="text-sm font-medium text-gray-500 truncate">Last Month</dt>
+            <dd class="mt-1 text-3xl tracking-tight font-semibold text-gray-900">
+                <h3>{{ $month['current']}} hits</h3>
+                <p class="text-gray-500 text-sm">Previous: {{ $month['previous'] }}</p>
+                <p class="text-gray-500 text-sm">Percent Change: {{ $month['change'] }}%</p>
+            </dd>
+        </div>
+
+        <div class="px-4 py-5 bg-white shadow rounded-lg overflow-hidden sm:p-6">
+            <dt class="text-sm font-medium text-gray-500 truncate">All Time</dt>
+            <dd class="mt-1 text-3xl tracking-tight font-semibold text-gray-900">
+                <h3>{{ $year['current']}} hits</h3>
+                <p class="text-gray-500 text-sm">Previous: {{ $year['previous'] }}</p>
+                <p class="text-gray-500 text-sm">Percent Change: {{ $year['change'] }}%</p>
+            </dd>
+        </div>
+
+        <div class="px-4 py-5 bg-white shadow rounded-lg overflow-hidden sm:p-6">
+            <dt class="text-sm font-medium text-gray-500 truncate">Top endpoint</dt>
+            <dd class="mt-1 text-xs tracking-tight font-semibold text-gray-900">
+                @foreach($top as $key => $value)
+                    <div class="flex justify-between my-2">
+                        <p>{{ $key }}</p>
+                        <p>{{ $value }}</p>
+                    </div>
+                @endforeach
+            </dd>
+        </div>
+    </dl>
+
+
+    <table class="min-w-full divide-y divide-gray-300">
+        <thead class="bg-gray-50">
+            <tr>
+                <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Endpoint</th>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">User Agent</th>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Date</th>
+            </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+            @foreach($hits as $hit)
+                <tr>
+                    <td class="whitespace-nowrap py-4 pl-4 text-sm text-gray-500">{{ $hit->endpoint}}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ $hit->user_agent}}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ $hit->created_at}}</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+@endsection

--- a/resources/views/stats.blade.php
+++ b/resources/views/stats.blade.php
@@ -7,7 +7,7 @@
             <dd class="mt-1 text-3xl tracking-tight font-semibold text-gray-900">
                 <h3>{{ $week['current'] }} hits</h3>
                 <p class="text-gray-500 text-sm">Previous: {{ $week['previous'] }}</p>
-                <p class="text-gray-500 text-sm">Percent Change: {{ $week['change'] }}%</p>
+                <p class="text-gray-500 text-sm">Percent Change: {{ $week['changePercent'] }}%</p>
             </dd>
         </div>
 
@@ -16,7 +16,7 @@
             <dd class="mt-1 text-3xl tracking-tight font-semibold text-gray-900">
                 <h3>{{ $month['current'] }} hits</h3>
                 <p class="text-gray-500 text-sm">Previous: {{ $month['previous'] }}</p>
-                <p class="text-gray-500 text-sm">Percent Change: {{ $month['change'] }}%</p>
+                <p class="text-gray-500 text-sm">Percent Change: {{ $month['changePercent'] }}%</p>
             </dd>
         </div>
 
@@ -25,17 +25,17 @@
             <dd class="mt-1 text-3xl tracking-tight font-semibold text-gray-900">
                 <h3>{{ $year['current'] }} hits</h3>
                 <p class="text-gray-500 text-sm">Previous: {{ $year['previous'] }}</p>
-                <p class="text-gray-500 text-sm">Percent Change: {{ $year['change'] }}%</p>
+                <p class="text-gray-500 text-sm">Percent Change: {{ $year['changePercent'] }}%</p>
             </dd>
         </div>
 
         <div class="px-4 py-5 bg-white shadow rounded-lg overflow-hidden sm:p-6">
-            <dt class="text-sm font-medium text-gray-500 truncate">Top Endpoints</dt>
+            <dt class="text-sm font-medium text-gray-500 truncate">Top Endpoints <span class="text-xs">(All Time)</span></dt>
             <dd class="mt-1 text-xs tracking-tight font-semibold text-gray-900">
-                @foreach ($top as $key => $value)
+                @foreach ($top as $topHit)
                     <div class="flex justify-between my-2">
-                        <p>{{ $key }}</p>
-                        <p>{{ $value }}</p>
+                        <p>{{ $topHit->endpoint }}</p>
+                        <p>{{ $topHit->count }}</p>
                     </div>
                 @endforeach
             </dd>
@@ -61,4 +61,6 @@
             @endforeach
         </tbody>
     </table>
+
+    {{ $hits->links() }}
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\HitController;
 use App\Http\Controllers\IndexController;
 use Illuminate\Support\Facades\Route;
 
@@ -15,3 +16,7 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/', [IndexController::class, 'index']);
+
+Route::middleware('auth.basic')
+    ->get('stats', HitController::class )
+    ->name('stats');

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,5 +18,5 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', [IndexController::class, 'index']);
 
 Route::middleware('auth.basic')
-    ->get('stats', HitController::class )
+    ->get('stats', HitController::class)
     ->name('stats');

--- a/tests/Feature/StatsTest.php
+++ b/tests/Feature/StatsTest.php
@@ -57,7 +57,7 @@ class StatsTest extends TestCase
         $this->assertSame([
             'current' => 6,
             'previous' => 2,
-            'change' => 200,
+            'changePercent' => 200,
         ], $hits);
     }
 
@@ -81,7 +81,7 @@ class StatsTest extends TestCase
         $this->assertSame([
             'current' => 2,
             'previous' => 6,
-            'change' => -66,
+            'changePercent' => -66,
         ], $hits);
     }
 
@@ -99,7 +99,7 @@ class StatsTest extends TestCase
         $this->assertSame([
             'current' => 2,
             'previous' => 0,
-            'change' => 100,
+            'changePercent' => 100,
         ], $hits);
     }
 }

--- a/tests/Feature/StatsTest.php
+++ b/tests/Feature/StatsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Hit;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Tests\TestCase;
+
+class StatsTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /** @test */
+    public function it_stores_the_hit()
+    {
+        $this->getJson('api/releases/8.0.0', [
+            'User-Agent' => 'My Test Agent',
+        ]);
+
+        $this->assertDatabaseHas('hits', [
+            'endpoint' => '/api/releases/8.0.0',
+            'user_agent' => 'My Test Agent',
+        ]);
+    }
+
+    /** @test */
+    public function it_ignores_bot_user_agents()
+    {
+        $this->getJson('api/releases/8.0.0', [
+            'User-Agent' => 'Mybot',
+        ]);
+
+        $this->assertDatabaseMissing('hits', [
+            'endpoint' => '/api/releases/8.0.0',
+            'user_agent' => 'Mybot',
+        ]);
+    }
+
+    /** @test */
+    public function it_calculates_percent_increase()
+    {
+        Hit::factory()
+            ->count(2)
+            ->create([
+                'created_at' => CarbonImmutable::now()->subWeek()->subDay(),
+            ]);
+
+        Hit::factory()
+            ->count(6)
+            ->create([
+                'created_at' => CarbonImmutable::now(),
+            ]);
+
+        $hits = Hit::forTimePeriod('week');
+
+        $this->assertSame([
+            'current' => 6,
+            'previous' => 2,
+            'change' => 200,
+        ], $hits);
+    }
+
+    /** @test */
+    public function it_handles_a_percent_decrease()
+    {
+        Hit::factory()
+            ->count(6)
+            ->create([
+                'created_at' => CarbonImmutable::now()->subMonth()->subDay(),
+            ]);
+
+        Hit::factory()
+            ->count(2)
+            ->create([
+                'created_at' => CarbonImmutable::now(),
+            ]);
+
+        $hits = Hit::forTimePeriod('month');
+
+        $this->assertSame([
+            'current' => 2,
+            'previous' => 6,
+            'change' => -66,
+        ], $hits);
+    }
+
+    /** @test */
+    public function it_handles_first_period_values()
+    {
+        Hit::factory()
+            ->count(2)
+            ->create([
+                'created_at' => CarbonImmutable::now(),
+            ]);
+
+        $hits = Hit::forTimePeriod('year');
+
+        $this->assertSame([
+            'current' => 2,
+            'previous' => 0,
+            'change' => 100,
+        ], $hits);
+    }
+}


### PR DESCRIPTION
Adds simple hit tracking to record the count of hits and most popular endpoints. We're also recording user agent data for the sole purpose of filtering out bots that I probably missed.

![Screenshot 2022-08-29 at 09-52-34 PHP Releases Tighten](https://user-images.githubusercontent.com/4378273/187217256-58c8383a-8c09-4e26-9ebc-79290adcbbad.png)
