### PR TITLE
Configure tests to run after Duster

### DIFF
--- a/.github/workflows/duster.yml
+++ b/.github/workflows/duster.yml
@@ -1,9 +1,9 @@
 name: Duster Fix
 
 on:
-    push:
-        branches: main
-    pull_request:
+  pull_request:
+  push:
+    branches: main
 
 jobs:
   duster:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,12 @@
 name: tests
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
+  # Commits made in Duster Fix will not trigger any workflows
+  # Tests are configured to run after the workflow finishes
+  workflow_run:
+    workflows: ["Duster Fix"]
+    types:
+      - completed
 
 jobs:
   test:


### PR DESCRIPTION
This PR configures the test GitHub workflow to run after Duster finishes.

When Duster fixes the codebase, the resulting commit will not trigger another GitHub Actions Workflow run. This is due to [limitations set by GitHub](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).

>When you use the repository's GITHUB_TOKEN to perform tasks on behalf of the GitHub Actions app, events triggered by the GITHUB_TOKEN will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.

The commit also stops any current workflows running. This means the last three commits to the repository would not have been tested.

The testing workflow has been updated to run after Duster completes.