### PR TITLE
Add global scope to ensure we only calculate hits on endpoints matching the /api route prefix

### DIFF
--- a/app/Models/Hit.php
+++ b/app/Models/Hit.php
@@ -59,5 +59,9 @@ class Hit extends Model
         static::addGlobalScope('order', function (Builder $builder) {
             $builder->orderBy('created_at', 'desc');
         });
+
+        static::addGlobalScope('api', function (Builder $builder) {
+            $builder->where('endpoint', 'LIKE', '/api/%');
+        });
     }
 }

--- a/app/Notifications/WeeklyStats.php
+++ b/app/Notifications/WeeklyStats.php
@@ -30,7 +30,7 @@ class WeeklyStats extends Notification
                 $block->type('header')
                     ->text([
                         'type' => 'plain_text',
-                        'text' => 'PHP Releases Weekly Hits!',
+                        'text' => 'PHP Releases Weekly API Hits!',
                     ]);
             })
             ->block(function ($block) use ($hits) {

--- a/tests/Feature/StatsTest.php
+++ b/tests/Feature/StatsTest.php
@@ -46,6 +46,30 @@ class StatsTest extends TestCase
     }
 
     /** @test */
+    public function it_filters_out_web_requests(): void
+    {
+        Hit::factory()
+            ->count(2)
+            ->create([
+                'endpoint' => '/',
+            ]);
+
+        Hit::factory()
+            ->count(2)
+            ->create([
+                'endpoint' => '/api/releases',
+            ]);
+
+        $hits = Hit::forTimePeriod('week');
+
+        $this->assertSame([
+            'current' => 2,
+            'previous' => 0,
+            'changePercent' => 100,
+        ], $hits);
+    }
+
+    /** @test */
     public function it_calculates_percent_increase()
     {
         Hit::factory()


### PR DESCRIPTION
- Add a global scope on the Hit model to filter records where the endpoint attribute starts with `/api`.
- Update the Slack notification header to specify that the stats are for API hits.